### PR TITLE
New expansion `Orders` type

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ fn solve_basic_problem() -> Result<(), Box<dyn std::error::Error>> {
     let mut mesh = Mesh::from_file("./test_input/test_mesh_a.json")?;
 
     // Set the polynomial expansion order to 4 in both directions on all Elems
-    mesh.set_global_expansion_orders(Orders::new_unwrapped(4, 4));
+    mesh.set_global_expansion_orders(Orders::new(4, 4));
 
     // Isotropically refine all Elems
     mesh.global_h_refinement(HRef::t());

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Rust library for 2D Finite Element Method computations, featuring:
 
 - Highly flexible *hp*-Refinement
   - Isotropic & Anisotropic *h*-refinements (with support for n-irregularity)
-  - Isotropic & Anisotropic *p*-refinements 
+  - Isotropic & Anisotropic *p*-refinements
 - Generic shape function evaluation
   - You can use one of the two built in sets of H(curl) conforming Shape Functions
   - Or you can define your own by implementing the `ShapeFn` Trait
@@ -24,7 +24,7 @@ fem_2d = "0.1.0"
 ```
 
 Please include one or more of the following citations in any academic or commercial work based on this repository:
-* Corrado, Jeremiah; Harmon, Jake; Notaros, Branislav; Ilic, Milan M. (2022): FEM_2D: A Rust Package for 2D Finite Element Method Computations with Extensive Support for hp-refinement. TechRxiv. Preprint. [https://doi.org/10.36227/techrxiv.19166339.v1](https://doi.org/10.36227/techrxiv.19166339.v1) 
+* Corrado, Jeremiah; Harmon, Jake; Notaros, Branislav; Ilic, Milan M. (2022): FEM_2D: A Rust Package for 2D Finite Element Method Computations with Extensive Support for hp-refinement. TechRxiv. Preprint. [https://doi.org/10.36227/techrxiv.19166339.v1](https://doi.org/10.36227/techrxiv.19166339.v1)
 * Corrado, Jeremiah; Harmon, Jake; Notaros, Branislav (2021): A Refinement-by-Superposition Approach to Fully Anisotropic hp-Refinement for Improved Efficiency in CEM. TechRxiv. Preprint. [https://doi.org/10.36227/techrxiv.16695163.v1](https://doi.org/10.36227/techrxiv.16695163.v1)
 * Harmon, Jake; Corrado, Jeremiah; Notaros, Branislav (2021): A Refinement-by-Superposition hp-Method for H(curl)- and H(div)-Conforming Discretizations. TechRxiv. Preprint. [https://doi.org/10.36227/techrxiv.14807895.v1](https://doi.org/10.36227/techrxiv.14807895.v1)
 
@@ -45,7 +45,7 @@ fn solve_basic_problem() -> Result<(), Box<dyn std::error::Error>> {
     let mut mesh = Mesh::from_file("./test_input/test_mesh_a.json")?;
 
     // Set the polynomial expansion order to 4 in both directions on all Elems
-    mesh.set_global_expansion_orders([4, 4])?;
+    mesh.set_global_expansion_orders(Orders::new_unwrapped(4, 4));
 
     // Isotropically refine all Elems
     mesh.global_h_refinement(HRef::t());
@@ -67,8 +67,8 @@ fn solve_basic_problem() -> Result<(), Box<dyn std::error::Error>> {
     // Construct a generalized eigenvalue problem for the Electric Field
     // (in parallel using the Rayon Global ThreadPool)
     let gep = galerkin_sample_gep_hcurl::<
-        HierPoly, 
-        CurlCurl, 
+        HierPoly,
+        CurlCurl,
         L2Inner
     >(&domain, Some([8, 8]))?;
 
@@ -111,7 +111,7 @@ Three types of h-refinement are supported:
 These are designated as an Enum: `HRef`, located in the `h_refinements` module. They can be executed by constructing a refinement as follows:
 ```Rust
 let h_iso = HRef::T;
-let h_aniso_u = HRef::U(None); 
+let h_aniso_u = HRef::U(None);
 let h_aniso_v = HRef::V(None);
 ```
 ...and applying it to an element or group of elements using one of the many *h*-refinement methods on `Mesh`.
@@ -135,9 +135,9 @@ let u_plus_1_v_minus_3 = PRef::from(1, -3);
 
 ## JSON Mesh Files
 
-fem_2d uses `.json` files to import and export Mesh layouts. 
+fem_2d uses `.json` files to import and export Mesh layouts.
 
-* The input format is simplified and describes the geometry of the problem only. 
+* The input format is simplified and describes the geometry of the problem only.
 * The output format describes the Mesh in it's refined state which is usefull for debugging and observing the refinement state.
 
 ### Input Mesh Files
@@ -208,5 +208,4 @@ Contributions, questions, and bug-reports are welcome! Any pull requests, issues
 
 More details about how to contribute to this project can be found [here](https://github.com/jeremiah-corrado/fem_2d/blob/main/rm_figs/contributing.md).
 
-Questions and bug-reports should be directed to the Issues tab. 
-
+Questions and bug-reports should be directed to the Issues tab.

--- a/paper.md
+++ b/paper.md
@@ -144,7 +144,7 @@ fn do_some_p_refinements(mesh: &mut Mesh) -> Result<(), PRefError> {
 
 The `Mesh` data structure also has an alternative set of methods to modify expansion orders by setting them directly rather than additively. These methods can be very useful in scenarios where the current expansion orders are irrelevant, and elements require a specific expansion order which is either known beforehand or computed ad-hoc. The following shows how this API may be used in practice.
 
-Here, both methods take an `Orders` object that specifies the expansion order in the `u` and `v` directions. In the first method, `try_new` is used to construct an `Orders`. This can fail if the expansion order specified is either `0` or greater than the maximum allowed expansion order: `MAX_POLYNOMIAL_ORDER`. The second interface takes a closure which creates an `Option<Orders>` for each element (in this example, the closure uses `new_unwrapped` which will panic when provided with invalid expansion orders).
+Here, both methods take an `Orders` object that specifies the expansion order in the `u` and `v` directions. In the first method, `try_new` is used to construct an `Orders`. This can fail if the expansion order specified is either `0` or greater than the maximum allowed expansion order: `MAX_POLYNOMIAL_ORDER`. The second interface takes a closure which creates an `Option<Orders>` for each element (in this example, the closure uses `Orders::new` which will panic when provided with invalid expansion orders).
 ```rust
 use fem_2d::prelude::*;
 
@@ -157,9 +157,9 @@ fn set_some_expansion_orders(mesh: &mut Mesh, order: u8) -> Result<(), PRefError
     // leave all other elems unchanged
     mesh.set_expansions_with_filter(|elem| {
         if !elem.has_children() {
-            Some(Orders::new_unwrapped(4, 4))
+            Some(Orders::new(4, 4))
         } else if elem.parent_id().is_none() {
-            Some(Orders::new_unwrapped(2, 2))
+            Some(Orders::new(2, 2))
         } else {
             None
         }

--- a/paper.md
+++ b/paper.md
@@ -144,12 +144,12 @@ fn do_some_p_refinements(mesh: &mut Mesh) -> Result<(), PRefError> {
 
 The `Mesh` data structure also has an alternative set of methods to modify expansion orders by setting them directly rather than additively. These methods can be very useful in scenarios where the current expansion orders are irrelevant, and elements require a specific expansion order which is either known beforehand or computed ad-hoc. The following shows how this API may be used in practice.
 
-Both methods take an `Orders` object that specifies the expansion order in the `u` and `v` directions. In the first method, `try_new` is used to construct an `Orders`. This can fail if the expansion order specified is either `0` or greater than the maximum allowed expansion order: `MAX_POLYNOMIAL_ORDER`. The second interface takes a closure which creates an `Option<Orders>` for each element.
+Here, both methods take an `Orders` object that specifies the expansion order in the `u` and `v` directions. In the first method, `try_new` is used to construct an `Orders`. This can fail if the expansion order specified is either `0` or greater than the maximum allowed expansion order: `MAX_POLYNOMIAL_ORDER`. The second interface takes a closure which creates an `Option<Orders>` for each element (in this example, the closure uses `new_unwrapped` which will panic when provided with invalid expansion orders).
 ```rust
 use fem_2d::prelude::*;
 
 fn set_some_expansion_orders(mesh: &mut Mesh, order: u8) -> Result<(), PRefError> {
-    // set the expansion order on all elems to (3, 3)
+    // set the expansion order on all elems to 'order'
     mesh.set_global_expansion_orders(Orders::try_new(order, order)?);
 
     // set the expansion orders to (4, 4) on all "leaf" elems

--- a/paper.md
+++ b/paper.md
@@ -144,27 +144,29 @@ fn do_some_p_refinements(mesh: &mut Mesh) -> Result<(), PRefError> {
 
 The `Mesh` data structure also has an alternative set of methods to modify expansion orders by setting them directly rather than additively. These methods can be very useful in scenarios where the current expansion orders are irrelevant, and elements require a specific expansion order which is either known beforehand or computed ad-hoc. The following shows how this API may be used in practice.
 
-Here, both methods can return an error, as it is possible to specify an invalid expansion order. These methods take a length-two array of `u8`'s (8-bit unsigned integers), and thus preemptively remove the possibility of setting negative expansion orders, however, they still Err on expansion orders that are zero or too large.
+Both methods take an `Orders` object that specifies the expansion order in the `u` and `v` directions. In the first method, `try_new` is used to construct an `Orders`. This can fail if the expansion order specified is either `0` or greater than the maximum allowed expansion order: `MAX_POLYNOMIAL_ORDER`. The second interface takes a closure which creates an `Option<Orders>` for each element.
 ```rust
 use fem_2d::prelude::*;
 
-fn set_some_expansion_orders(mesh: &mut Mesh) -> Result<(), PRefError> {
+fn set_some_expansion_orders(mesh: &mut Mesh, order: u8) -> Result<(), PRefError> {
     // set the expansion order on all elems to (3, 3)
-    mesh.set_global_expansion_orders([3, 3])?;
+    mesh.set_global_expansion_orders(Orders::try_new(order, order)?);
 
     // set the expansion orders to (4, 4) on all "leaf" elems
-    // set the expansion orders to (2, 2) on all other elems
+    // set the expansion orders to (2, 2) on all base layer elems
+    // leave all other elems unchanged
     mesh.set_expansions_with_filter(|elem| {
-        if elem.has_children() {
-            Some([2, 2])
+        if !elem.has_children() {
+            Some(Orders::new_unwrapped(4, 4))
+        } else if elem.parent_id().is_none() {
+            Some(Orders::new_unwrapped(2, 2))
         } else {
-            Some([4, 4])
+            None
         }
-    })?;
+    });
 
     Ok(())
 }
-
 ```
 
 ## Problem Formulation and Solution

--- a/src/fem_domain/domain.rs
+++ b/src/fem_domain/domain.rs
@@ -240,7 +240,7 @@ impl Domain {
     /// ```
     /// use fem_2d::prelude::*;
     /// let mut mesh = Mesh::unit();
-    /// mesh.set_global_expansion_orders([2, 2]).unwrap();
+    /// mesh.set_global_expansion_orders(Orders::new_unwrapped(2, 2));
     ///
     /// let dom = Domain::from_mesh(mesh, ContinuityCondition::HCurl);
     ///
@@ -271,7 +271,7 @@ impl Domain {
     /// use fem_2d::prelude::*;
     ///
     /// let mut mesh = Mesh::unit();
-    /// mesh.set_global_expansion_orders([2, 2]).unwrap();
+    /// mesh.set_global_expansion_orders(Orders::new_unwrapped(2, 2));
     /// mesh.global_h_refinement(HRef::T);
     ///
     /// let dom = Domain::from_mesh(mesh, ContinuityCondition::HCurl);
@@ -316,7 +316,7 @@ impl Domain {
     /// use fem_2d::prelude::*;
     ///
     /// let mut mesh = Mesh::unit();
-    /// mesh.set_global_expansion_orders([2, 2]);
+    /// mesh.set_global_expansion_orders(Orders::new_unwrapped(2, 2));
     /// mesh.global_h_refinement(HRef::T);
     /// mesh.h_refine_elems(vec![1], HRef::T).unwrap();
     ///
@@ -393,12 +393,12 @@ impl IdTracker {
 mod tests {
     use super::*;
     use mesh::h_refinement::HRef;
-    use mesh::p_refinement::PRef;
+    use mesh::p_refinement::{PRef, Orders};
 
     #[test]
     fn create_domain() {
         let mut mesh = Mesh::from_file("./test_input/test_mesh_a.json").unwrap();
-        mesh.set_global_expansion_orders([5, 5]).unwrap();
+        mesh.set_global_expansion_orders(Orders::try_new(5, 5).unwrap());
         mesh.global_h_refinement(HRef::T);
         mesh.h_refine_elems(vec![4, 5], HRef::T).unwrap();
         mesh.h_refine_elems(vec![6, 7], HRef::u()).unwrap();

--- a/src/fem_domain/domain.rs
+++ b/src/fem_domain/domain.rs
@@ -240,7 +240,7 @@ impl Domain {
     /// ```
     /// use fem_2d::prelude::*;
     /// let mut mesh = Mesh::unit();
-    /// mesh.set_global_expansion_orders(Orders::new_unwrapped(2, 2));
+    /// mesh.set_global_expansion_orders(Orders::new(2, 2));
     ///
     /// let dom = Domain::from_mesh(mesh, ContinuityCondition::HCurl);
     ///
@@ -271,7 +271,7 @@ impl Domain {
     /// use fem_2d::prelude::*;
     ///
     /// let mut mesh = Mesh::unit();
-    /// mesh.set_global_expansion_orders(Orders::new_unwrapped(2, 2));
+    /// mesh.set_global_expansion_orders(Orders::new(2, 2));
     /// mesh.global_h_refinement(HRef::T);
     ///
     /// let dom = Domain::from_mesh(mesh, ContinuityCondition::HCurl);
@@ -316,7 +316,7 @@ impl Domain {
     /// use fem_2d::prelude::*;
     ///
     /// let mut mesh = Mesh::unit();
-    /// mesh.set_global_expansion_orders(Orders::new_unwrapped(2, 2));
+    /// mesh.set_global_expansion_orders(Orders::new(2, 2));
     /// mesh.global_h_refinement(HRef::T);
     /// mesh.h_refine_elems(vec![1], HRef::T).unwrap();
     ///

--- a/src/fem_domain/domain/mesh.rs
+++ b/src/fem_domain/domain/mesh.rs
@@ -612,10 +612,10 @@ impl Mesh {
     /// let mut mesh = Mesh::unit();
     /// mesh.h_refine_elems(vec![0], HRef::T).unwrap();
     /// mesh.set_expansion_orders(vec![
-    ///     (1, Orders::new_unwrapped(1, 1)),
-    ///     (2, Orders::new_unwrapped(3, 3)),
-    ///     (3, Orders::new_unwrapped(2, 7)),
-    ///     (4, Orders::new_unwrapped(4, 1)),
+    ///     (1, Orders::new(1, 1)),
+    ///     (2, Orders::new(3, 3)),
+    ///     (3, Orders::new(2, 7)),
+    ///     (4, Orders::new(4, 1)),
     /// ]).unwrap();
     ///
     /// let [max_u_order, max_v_order] = mesh.max_expansion_orders();
@@ -1525,7 +1525,7 @@ impl Mesh {
     /// mesh.global_h_refinement(HRef::T);
     /// mesh.global_h_refinement(HRef::T);
     ///
-    /// mesh.set_global_expansion_orders(Orders::new_unwrapped(4, 5));
+    /// mesh.set_global_expansion_orders(Orders::new(4, 5));
     /// for elem in mesh.elems.iter() {
     ///     assert_eq!(elem.poly_orders.ni, 4);
     ///     assert_eq!(elem.poly_orders.nj, 5);
@@ -1551,7 +1551,7 @@ impl Mesh {
     /// assert_eq!(mesh.elems[0].poly_orders.nj, 1);
     ///
     /// // set expansion orders to `[6, 3]`
-    /// mesh.set_expansion_on_elems(vec![0], Orders::new_unwrapped(6, 3)).unwrap();
+    /// mesh.set_expansion_on_elems(vec![0], Orders::new(6, 3)).unwrap();
     ///
     /// // check that the expansion orders have been updated properly
     /// assert_eq!(mesh.elems[0].poly_orders.ni, 6);
@@ -1583,7 +1583,7 @@ impl Mesh {
     /// // modify the expansion orders on the elems that have been h-refined
     /// mesh.set_expansions_with_filter(|elem| {
     ///    if elem.has_children() {
-    ///         Some(Orders::new_unwrapped(4, 3))
+    ///         Some(Orders::new(4, 3))
     ///    } else {
     ///         None
     ///    }
@@ -1626,20 +1626,20 @@ impl Mesh {
     /// let mut mesh = Mesh::unit();
     ///
     /// // set elem 0's expansion orders to `[2, 2]`
-    /// mesh.set_expansion_orders(vec![ (0, Orders::new_unwrapped(2, 2)) ]).unwrap();
+    /// mesh.set_expansion_orders(vec![ (0, Orders::new(2, 2)) ]).unwrap();
     /// assert_eq!(mesh.elems[0].poly_orders.ni, 2);
     /// assert_eq!(mesh.elems[0].poly_orders.nj, 2);
     ///
     /// // duplicate elem_id error
     /// assert!(mesh.set_expansion_orders(vec![
-    ///     (0, Orders::new_unwrapped(2, 1)),
-    ///     (0, Orders::new_unwrapped(1, 2)),
+    ///     (0, Orders::new(2, 1)),
+    ///     (0, Orders::new(1, 2)),
     /// ]).is_err());
     ///
     /// // non-existent elem_id error
     /// assert!(mesh.set_expansion_orders(vec![
-    ///     (0, Orders::new_unwrapped(2, 2)),
-    ///     (7, Orders::new_unwrapped(2, 2)),
+    ///     (0, Orders::new(2, 2)),
+    ///     (7, Orders::new(2, 2)),
     /// ]).is_err());
     /// ```
     ///
@@ -2048,7 +2048,7 @@ mod tests {
     #[should_panic]
     fn neg_p_refinement_i() {
         let mut mesh_c = Mesh::from_file("./test_input/test_mesh_c.json").unwrap();
-        mesh_c.set_global_expansion_orders(Orders::new_unwrapped(3, 3));
+        mesh_c.set_global_expansion_orders(Orders::new(3, 3));
         mesh_c.p_refine_elems(vec![0], PRef::from(-3, 1)).unwrap();
     }
 
@@ -2056,7 +2056,7 @@ mod tests {
     #[should_panic]
     fn neg_p_refinement_j() {
         let mut mesh_c = Mesh::from_file("./test_input/test_mesh_c.json").unwrap();
-        mesh_c.set_global_expansion_orders(Orders::new_unwrapped(3, 3));
+        mesh_c.set_global_expansion_orders(Orders::new(3, 3));
 
         mesh_c.p_refine_elems(vec![0], PRef::from(1, -3)).unwrap();
     }

--- a/src/fem_domain/domain/mesh/p_refinement.rs
+++ b/src/fem_domain/domain/mesh/p_refinement.rs
@@ -283,7 +283,7 @@ impl Orders {
     /// Attempt to construct a new set of expansion `Orders`
     ///
     /// emits a compile error if either value is outside the valid range
-    pub fn new_unwrapped(i: u8, j: u8) -> Self {
+    pub fn new(i: u8, j: u8) -> Self {
         if i > MAX_POLYNOMIAL_ORDER || j > MAX_POLYNOMIAL_ORDER || i < 1 || j < 1 {
             panic!("Expansion orders outside valid range ({}, {})", i, j);
         }

--- a/src/fem_domain/domain/mesh/p_refinement.rs
+++ b/src/fem_domain/domain/mesh/p_refinement.rs
@@ -259,6 +259,49 @@ impl fmt::Display for PRef {
     }
 }
 
+/// A pair of expansion orders for an `Elem`
+///
+/// Used to directly set an `Elem`'s expansion order rather than using a `PRef` to modify it
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Orders {
+    i: u8,
+    j: u8,
+}
+
+impl Orders {
+    /// Attempt to construct a new set of expansion `Orders`
+    ///
+    /// Returns a `PRefError` if either value is outside the valid range
+    pub fn try_new(i: u8, j: u8) -> Result<Self, PRefError> {
+        if i > MAX_POLYNOMIAL_ORDER || j > MAX_POLYNOMIAL_ORDER || i < 1 || j < 1 {
+            Err(PRefError::InvalidExpansionOrders(i, j))
+        } else {
+            Ok(Self { i, j })
+        }
+    }
+
+    /// Attempt to construct a new set of expansion `Orders`
+    ///
+    /// emits a compile error if either value is outside the valid range
+    pub fn new_unwrapped(i: u8, j: u8) -> Self {
+        if i > MAX_POLYNOMIAL_ORDER || j > MAX_POLYNOMIAL_ORDER || i < 1 || j < 1 {
+            panic!("Expansion orders outside valid range ({}, {})", i, j);
+        }
+        Self { i, j }
+    }
+
+    // Convert the `Orders` into an array of values `[i, j]`
+    pub fn to_array(self) -> [u8; 2] {
+        [self.i, self.j]
+    }
+}
+
+impl fmt::Display for Orders {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Orders (i: {}, j: {})", self.i, self.j)
+    }
+}
+
 /// The Error Type for invalid p-refinements
 #[derive(Debug)]
 pub enum PRefError {
@@ -269,6 +312,7 @@ pub enum PRefError {
     DuplicateElemIds,
     ElemDoesNotExist(usize),
     RefinementOutOfBounds(usize),
+    InvalidExpansionOrders(u8, u8),
 }
 
 impl std::error::Error for PRefError {}
@@ -298,6 +342,12 @@ impl fmt::Display for PRefError {
                 "Refinement out of bounds for Elem {}; Cannot apply p-Refinement!",
                 elem_id
             ),
+            Self::InvalidExpansionOrders(i, j) => write!(
+                f,
+                "Invalid expansion orders: ({}, {})",
+                i,
+                j
+            )
         }
     }
 }

--- a/src/fem_domain/domain/mesh/space.rs
+++ b/src/fem_domain/domain/mesh/space.rs
@@ -42,9 +42,13 @@ impl Default for V2D {
 impl fmt::Display for V2D {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if let Some(precision) = f.precision() {
-            write!(f, "({:.*}, {:.*})", precision, self.inner[0], precision, self.inner[1])
+            write!(
+                f,
+                "({:.*}, {:.*})",
+                precision, self.inner[0], precision, self.inner[1]
+            )
         } else {
-            write!(f, "[{}, {}]", self.inner[0], self.inner[1])  
+            write!(f, "[{}, {}]", self.inner[0], self.inner[1])
         }
     }
 }
@@ -180,7 +184,11 @@ impl Mul<V2D> for M2D {
 impl fmt::Display for M2D {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if let Some(precision) = f.precision() {
-            write!(f, "u: {:.*}, v: {:.*}", precision, self.u, precision, self.v)
+            write!(
+                f,
+                "u: {:.*}, v: {:.*}",
+                precision, self.u, precision, self.v
+            )
         } else {
             write!(f, "u: {}, v: {}", self.u, self.v)
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub mod prelude {
         mesh::{
             elem::Elem,
             h_refinement::{HRef, HRefError},
-            p_refinement::{PRef, PRefError},
+            p_refinement::{PRef, Orders, PRefError},
             Mesh,
         },
         ContinuityCondition, Domain,


### PR DESCRIPTION
Adds a new type to express a pair of expansion orders.

This replaces the `[u8; 2]` argument in: `set_global_expansion_orders`, `set_expansion_on_elems`, `set_expansions_with_filter`, & `set_expansion_orders`.

This way, erroneous expansion orders can be caught when the `Orders` is constructed rather than during one of the execution of one of the above methods. 

The paper and documentation are updated to reflect this change.
